### PR TITLE
BigInt base conversion and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install
+      - name: Run tests
+        run: bun test

--- a/components/NumberConverterInput/convertBase.test.ts
+++ b/components/NumberConverterInput/convertBase.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "bun:test";
+import convertBase from "./convertBase";
+
+describe("convertBase", () => {
+  describe("basic conversions", () => {
+    it("converts 0 in any base to 0", () => {
+      expect(convertBase("0", 10, 2)).toBe("0");
+      expect(convertBase("0", 2, 16)).toBe("0");
+      expect(convertBase("0", 64, 10)).toBe("0");
+    });
+
+    it("converts decimal to binary", () => {
+      expect(convertBase("10", 10, 2)).toBe("1010");
+      expect(convertBase("255", 10, 2)).toBe("11111111");
+    });
+
+    it("converts binary to decimal", () => {
+      expect(convertBase("1010", 2, 10)).toBe("10");
+      expect(convertBase("11111111", 2, 10)).toBe("255");
+    });
+
+    it("converts decimal to hex (uppercase output)", () => {
+      expect(convertBase("255", 10, 16)).toBe("FF");
+      expect(convertBase("16", 10, 16)).toBe("10");
+    });
+
+    it("converts hex to decimal (case-insensitive input)", () => {
+      expect(convertBase("A", 16, 10)).toBe("10");
+      expect(convertBase("a", 16, 10)).toBe("10");
+      expect(convertBase("ff", 16, 10)).toBe("255");
+      expect(convertBase("FF", 16, 10)).toBe("255");
+    });
+
+    it("converts base 36 max digit", () => {
+      expect(convertBase("Z", 36, 10)).toBe("35");
+      expect(convertBase("z", 36, 10)).toBe("35");
+    });
+
+    it("identity conversion (same base)", () => {
+      expect(convertBase("1", 10, 10)).toBe("1");
+      expect(convertBase("ABC", 16, 16)).toBe("ABC");
+    });
+
+    it("handles single digit", () => {
+      expect(convertBase("1", 2, 10)).toBe("1");
+      expect(convertBase("F", 16, 10)).toBe("15");
+    });
+
+    it("returns empty string for empty input", () => {
+      expect(convertBase("", 10, 2)).toBe("");
+    });
+  });
+
+  describe("large numbers beyond Number.MAX_SAFE_INTEGER", () => {
+    it("converts 2^53 (Number.MAX_SAFE_INTEGER + 1) correctly", () => {
+      // 2^53 = 9007199254740992
+      expect(convertBase("9007199254740992", 10, 2)).toBe(
+        "100000000000000000000000000000000000000000000000000000"
+      );
+      expect(convertBase("100000000000000000000000000000000000000000000000000000", 2, 10)).toBe(
+        "9007199254740992"
+      );
+    });
+
+    it("converts max uint64 (2^64 - 1) correctly", () => {
+      // FFFFFFFFFFFFFFFF hex = 18446744073709551615 decimal
+      expect(convertBase("FFFFFFFFFFFFFFFF", 16, 10)).toBe("18446744073709551615");
+      expect(convertBase("18446744073709551615", 10, 16)).toBe("FFFFFFFFFFFFFFFF");
+    });
+
+    it("round-trips large decimal through hex", () => {
+      const large = "18446744073709551615";
+      expect(convertBase(convertBase(large, 10, 16), 16, 10)).toBe(large);
+    });
+
+    it("round-trips large decimal through binary", () => {
+      const large = "9999999999999999";
+      expect(convertBase(convertBase(large, 10, 2), 2, 10)).toBe(large);
+    });
+
+    it("correctly converts 9999999999999999 (the reported bug case)", () => {
+      // This was the value that triggered the bug — must NOT round to 10000000000000000
+      const result = convertBase("9999999999999999", 10, 10);
+      expect(result).toBe("9999999999999999");
+      expect(result).not.toBe("10000000000000000");
+    });
+
+    it("handles very large numbers (2^128 - 1)", () => {
+      const maxUint128Hex = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+      const maxUint128Dec = "340282366920938463463374607431768211455";
+      expect(convertBase(maxUint128Hex, 16, 10)).toBe(maxUint128Dec);
+      expect(convertBase(maxUint128Dec, 10, 16)).toBe(maxUint128Hex);
+    });
+  });
+
+  describe("high-base conversions (base > 36, case-sensitive)", () => {
+    it("treats lowercase and uppercase as different digits in base > 36", () => {
+      // In base 64: 0-9 = 0-9, A-Z = 10-35, a-z = 36-61, + = 62, / = 63
+      expect(convertBase("a", 64, 10)).toBe("36");
+      expect(convertBase("A", 64, 10)).toBe("10");
+    });
+
+    it("converts + and / (base 64 digits)", () => {
+      expect(convertBase("+", 64, 10)).toBe("62");
+      expect(convertBase("/", 64, 10)).toBe("63");
+    });
+
+    it("round-trips through base 64", () => {
+      const val = "255";
+      expect(convertBase(convertBase(val, 10, 64), 64, 10)).toBe(val);
+    });
+  });
+
+  describe("error cases", () => {
+    it("throws RangeError when fromBase < 2", () => {
+      expect(() => convertBase("1", 1, 10)).toThrow(RangeError);
+    });
+
+    it("throws RangeError when toBase < 2", () => {
+      expect(() => convertBase("1", 10, 1)).toThrow(RangeError);
+    });
+
+    it("throws RangeError when fromBase > 64", () => {
+      expect(() => convertBase("1", 65, 10)).toThrow(RangeError);
+    });
+
+    it("throws RangeError when toBase > 64", () => {
+      expect(() => convertBase("1", 10, 65)).toThrow(RangeError);
+    });
+
+    it("throws Error for digit invalid in fromBase", () => {
+      expect(() => convertBase("2", 2, 10)).toThrow(Error);
+      expect(() => convertBase("G", 16, 10)).toThrow(Error);
+      expect(() => convertBase("Z", 10, 2)).toThrow(Error);
+    });
+  });
+});

--- a/components/NumberConverterInput/convertBase.ts
+++ b/components/NumberConverterInput/convertBase.ts
@@ -46,18 +46,18 @@ const convertBase = (
   let decValue = value
     .split("")
     .reverse()
-    .reduce((carry: number, digit: string, index: number) => {
+    .reduce((carry: bigint, digit: string, index: number) => {
       const fromIndex = fromRange.indexOf(digit);
       if (fromIndex === -1) {
         throw new Error(`Invalid digit ${digit} for base ${fromBase}.`);
       }
-      return carry + fromIndex * Math.pow(fromBase, index);
-    }, 0);
+      return carry + BigInt(fromIndex) * BigInt(fromBase) ** BigInt(index);
+    }, 0n);
 
   let newValue = value === "0" ? "0" : "";
-  while (decValue > 0) {
-    newValue = toRange[decValue % toBase] + newValue;
-    decValue = Math.floor(decValue / toBase); // Use Math.floor for integer division
+  while (decValue > 0n) {
+    newValue = toRange[Number(decValue % BigInt(toBase))] + newValue;
+    decValue = decValue / BigInt(toBase);
   }
   return newValue || "";
 };

--- a/components/NumberConverterInput/index.tsx
+++ b/components/NumberConverterInput/index.tsx
@@ -9,6 +9,7 @@ import { AnimatedCopyButton } from "../animated-copy-button";
 
 const BASE_TEN_PLACEHOLDER = "123";
 const ERROR_MESSAGE_DURATION_MS = 4000;
+const MAX_INPUT_LENGTH = 300;
 
 type NumberConverterInputProps = {
   label: string;
@@ -80,6 +81,29 @@ export const NumberConverterInput = ({
           },
         });
       }
+    }
+
+    if (validInput.length > MAX_INPUT_LENGTH) {
+      if (isMobile) {
+        if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
+        if (exitTimeoutRef.current) clearTimeout(exitTimeoutRef.current);
+        setError(`Input too large (max ${MAX_INPUT_LENGTH} digits)`);
+        setIsExiting(false);
+        errorTimeoutRef.current = setTimeout(() => {
+          setIsExiting(true);
+          exitTimeoutRef.current = setTimeout(() => {
+            setError("");
+            setIsExiting(false);
+          }, 200);
+        }, ERROR_MESSAGE_DURATION_MS);
+      } else {
+        toast.warning("Input too large", {
+          description: `Maximum input length is ${MAX_INPUT_LENGTH} digits`,
+          id: `input-too-large-base-${base}`,
+          classNames: { title: "font-bold text-lg" },
+        });
+      }
+      return;
     }
 
     setBaseTenValue(convertBase(validInput, base, 10));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "bun test"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
Use BigInt in convertBase to correctly handle very large numbers and avoid rounding issues beyond Number.MAX_SAFE_INTEGER. Add a comprehensive bun:test suite (components/NumberConverterInput/convertBase.test.ts) and a GitHub Actions workflow (.github/workflows/test.yml) to run bun install and bun test on PRs. Add a MAX_INPUT_LENGTH (300) check in NumberConverterInput to surface a user-facing error/toast for oversized inputs. Also add a package.json test script to run bun test.