### PR TITLE
Remove endianness controls; add @types/bun

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
 name: Test
 
 on:
+  push:
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Number Converter
 
-[![Vercel Deploy](https://deploy-badge.vercel.app/vercel/number-converter-tool?style=for-the-badge)](https://number-converter-tool.vercel.app/) [![Licence](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge)](./LICENSE)
+[![Vercel Deploy](https://deploy-badge.vercel.app/vercel/number-converter-tool?style=for-the-badge)](https://number-converter-tool.vercel.app/) [![Tests](https://img.shields.io/github/actions/workflow/status/stapletl/number-converter-tool/test.yml?style=for-the-badge&label=Tests)](https://github.com/stapletl/number-converter-tool/actions/workflows/test.yml) [![Licence](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge)](./LICENSE)
 
 ## About
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -145,17 +145,10 @@ const Home: React.FC = () => {
           <CardDescription>Real-time base conversion</CardDescription>
           <CardAction>
             <div className="flex gap-2">
-              <DataTypeRangeStatus
-                baseTenValue={num}
-                endianness={preferences.endianness}
-              />
+              <DataTypeRangeStatus baseTenValue={num} />
               <BaseSettingsPopover
                 selectedBases={selectedBases}
                 onSelectionChange={handleBaseSelectionChange}
-                endianness={preferences.endianness}
-                onEndiannessChange={(endianness) =>
-                  updatePreferences({ endianness })
-                }
               />
             </div>
           </CardAction>

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.561.0",
+        "lucide-react": "^0.577.0",
         "next": "16.0.10",
         "next-themes": "^0.4.6",
         "react": "19.2.3",
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
+        "@types/bun": "^1.3.10",
         "@types/node": "^25.0.2",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -287,6 +288,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -408,6 +411,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.0", "", { "dependencies": { "baseline-browser-mapping": "^2.8.25", "caniuse-lite": "^1.0.30001754", "electron-to-chromium": "^1.5.249", "node-releases": "^2.0.27", "update-browserslist-db": "^1.1.4" }, "bin": { "browserslist": "cli.js" } }, "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -719,7 +724,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@0.561.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Y59gMY38tl4/i0qewcqohPdEbieBy7SovpBL9IFebhc2mDd8x4PZSOsiFRkpPcOq6bj1r/mjH/Rk73gSlIJP2A=="],
+    "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/components/BaseSettingsPopover/index.tsx
+++ b/components/BaseSettingsPopover/index.tsx
@@ -6,23 +6,17 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Switch } from "@/components/ui/switch";
 import { AVAILABLE_BASES, type BaseId } from "@/lib/baseConfig";
-import type { Endianness } from "@/lib/byteUtils";
 import { Settings } from "lucide-react";
 
 type BaseSettingsPopoverProps = {
   selectedBases: BaseId[];
   onSelectionChange: (selectedIds: BaseId[]) => void;
-  endianness: Endianness;
-  onEndiannessChange: (endianness: Endianness) => void;
 };
 
 export function BaseSettingsPopover({
   selectedBases,
   onSelectionChange,
-  endianness,
-  onEndiannessChange,
 }: BaseSettingsPopoverProps) {
   const handleToggle = (baseId: BaseId, checked: boolean | "indeterminate") => {
     if (checked === "indeterminate") return;
@@ -68,26 +62,6 @@ export function BaseSettingsPopover({
                 </div>
               );
             })}
-          </div>
-          <div className="pt-3 border-t space-y-3">
-            <h4 className="font-medium text-sm">Byte Order</h4>
-            <div className="flex items-center justify-between">
-              <Label htmlFor="endianness-toggle" className="text-sm font-normal">
-                Little-endian
-              </Label>
-              <Switch
-                id="endianness-toggle"
-                checked={endianness === "little"}
-                onCheckedChange={(checked) =>
-                  onEndiannessChange(checked ? "little" : "big")
-                }
-              />
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {endianness === "big"
-                ? "Most significant byte first (Big-endian)"
-                : "Least significant byte first (Little-endian)"}
-            </p>
           </div>
         </div>
       </PopoverContent>

--- a/components/DataTypeRangeStatus/index.tsx
+++ b/components/DataTypeRangeStatus/index.tsx
@@ -9,18 +9,15 @@ import { AVAILABLE_DATA_TYPES, isInRange } from "@/lib/dataTypeConfig";
 import {
   formatByteRepresentation,
   isMultiByte,
-  type Endianness,
 } from "@/lib/byteUtils";
 import { LaptopMinimalCheck, Check, X } from "lucide-react";
 
 type DataTypeRangeStatusProps = {
   baseTenValue: string;
-  endianness: Endianness;
 };
 
 export function DataTypeRangeStatus({
   baseTenValue,
-  endianness,
 }: DataTypeRangeStatusProps) {
   return (
     <Popover>
@@ -43,7 +40,6 @@ export function DataTypeRangeStatus({
                 ? formatByteRepresentation(
                     baseTenValue,
                     dataType.id,
-                    endianness
                   )
                 : null;
 

--- a/lib/byteUtils.ts
+++ b/lib/byteUtils.ts
@@ -65,7 +65,7 @@ function valueToBytes(
 export function formatByteRepresentation(
   value: string,
   dataTypeId: DataTypeId,
-  endianness: Endianness
+  endianness: Endianness = "big"
 ): ByteRepresentation | null {
   // Return null for empty or partial input
   if (!value || value === "" || value === "-") return null;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
+    "@types/bun": "^1.3.10",
     "@types/node": "^25.0.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "types": ["@types/bun"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Remove the byte-order (endianness) setting and UI: stop passing endianness to DataTypeRangeStatus and BaseSettingsPopover, remove the endianness toggle and Switch import, and simplify related prop handling in BaseSettingsPopover and app/page.tsx. Also add @types/bun to devDependencies and include it in tsconfig "types" to enable Bun type support during development.